### PR TITLE
Remove delay from `Transcode.ToAnimated`

### DIFF
--- a/transformation-builder/src/main/kotlin/com/cloudinary/transformation/transcode/TranscodeActions.kt
+++ b/transformation-builder/src/main/kotlin/com/cloudinary/transformation/transcode/TranscodeActions.kt
@@ -14,13 +14,11 @@ class StreamingProfileAction internal constructor(private val profile: Any) : Tr
 // TODO no format enum?
 class ToAnimated(
     private val animatedFormat: Any,
-    private val sampling: Any? = null,
-    private val delay: Int? = null
+    private val sampling: Any? = null
 ) : Transcode() {
 
     override fun toString(): String {
         return listOfNotNull(
-            delay?.let { Param("dl", it) },
             Param("f", animatedFormat),
             Param("fl", "animated"),
             if (animatedFormat.toString().toLowerCase(Locale.ROOT) == "webp") Param("fl", "awebp") else null,
@@ -33,13 +31,11 @@ class ToAnimated(
         constructor(animatedFormat: String) : this(animatedFormat as Any)
 
         private var sampling: Any? = null
-        private var delay: Int? = null
 
         fun sampling(videoSampling: Int) = apply { this.sampling = videoSampling }
         fun sampling(videoSampling: String) = apply { this.sampling = videoSampling }
-        fun delay(delay: Int) = apply { this.delay = delay }
 
-        override fun build() = ToAnimated(animatedFormat, sampling, delay)
+        override fun build() = ToAnimated(animatedFormat, sampling)
     }
 
 

--- a/transformation-builder/src/main/kotlin/com/cloudinary/transformation/transcode/TranscodeActions.kt
+++ b/transformation-builder/src/main/kotlin/com/cloudinary/transformation/transcode/TranscodeActions.kt
@@ -14,11 +14,13 @@ class StreamingProfileAction internal constructor(private val profile: Any) : Tr
 // TODO no format enum?
 class ToAnimated(
     private val animatedFormat: Any,
-    private val sampling: Any? = null
+    private val sampling: Any? = null,
+    private val delay: Int? = null
 ) : Transcode() {
 
     override fun toString(): String {
         return listOfNotNull(
+            delay?.let { Param("dl", it) },
             Param("f", animatedFormat),
             Param("fl", "animated"),
             if (animatedFormat.toString().toLowerCase(Locale.ROOT) == "webp") Param("fl", "awebp") else null,
@@ -31,11 +33,15 @@ class ToAnimated(
         constructor(animatedFormat: String) : this(animatedFormat as Any)
 
         private var sampling: Any? = null
+        private var delay: Int? = null
 
         fun sampling(videoSampling: Int) = apply { this.sampling = videoSampling }
         fun sampling(videoSampling: String) = apply { this.sampling = videoSampling }
 
-        override fun build() = ToAnimated(animatedFormat, sampling)
+        @Deprecated("This function will be removed in the next major version, use Animated.edit instead")
+        fun delay(delay: Int) = apply { this.delay = delay }
+
+        override fun build() = ToAnimated(animatedFormat, sampling, delay)
     }
 
 

--- a/transformation-builder/src/test/kotlin/com/cloudinary/transformation/TranscodeTest.kt
+++ b/transformation-builder/src/test/kotlin/com/cloudinary/transformation/TranscodeTest.kt
@@ -25,10 +25,12 @@ class TranscodeTest {
     @Test
     fun toAnimated() {
         cldAssert("f_webp,fl_animated,fl_awebp", Transcode.toAnimated("webp"))
-        cldAssert("f_gif,fl_animated,vs_3", Transcode.toAnimated("gif") {
+        cldAssert("dl_100,f_gif,fl_animated,vs_3", Transcode.toAnimated("gif") {
+            delay(100)
             sampling(3)
         })
-        cldAssert("f_webp,fl_animated,fl_awebp,vs_3", Transcode.toAnimated(AnimatedFormat.webp()) {
+        cldAssert("dl_100,f_webp,fl_animated,fl_awebp,vs_3", Transcode.toAnimated(AnimatedFormat.webp()) {
+            delay(100)
             sampling(3)
         })
     }

--- a/transformation-builder/src/test/kotlin/com/cloudinary/transformation/TranscodeTest.kt
+++ b/transformation-builder/src/test/kotlin/com/cloudinary/transformation/TranscodeTest.kt
@@ -25,12 +25,10 @@ class TranscodeTest {
     @Test
     fun toAnimated() {
         cldAssert("f_webp,fl_animated,fl_awebp", Transcode.toAnimated("webp"))
-        cldAssert("dl_100,f_gif,fl_animated,vs_3", Transcode.toAnimated("gif") {
-            delay(100)
+        cldAssert("f_gif,fl_animated,vs_3", Transcode.toAnimated("gif") {
             sampling(3)
         })
-        cldAssert("dl_100,f_webp,fl_animated,fl_awebp,vs_3", Transcode.toAnimated(AnimatedFormat.webp()) {
-            delay(100)
+        cldAssert("f_webp,fl_animated,fl_awebp,vs_3", Transcode.toAnimated(AnimatedFormat.webp()) {
             sampling(3)
         })
     }


### PR DESCRIPTION
### Brief Summary of Changes
Removed delay from `Transcode.toAnimated`
@const-cloudinary I think this is a breaking changes and requires a major version

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [ ] New feature
- [x] Bug fix
- [ ] Adds more tests

#### Are tests included?
- [x] Yes
- [ ] No

#### Reviewer, please note:

#### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all the tests pass.
